### PR TITLE
[Jitera] Create/Update models and migrations

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,13 @@
+
 class Category < ApplicationRecord
   has_many :product_categories, dependent: :destroy
+  has_many :todos, dependent: :destroy
 
+  belongs_to :admin
   belongs_to :created,
              class_name: 'Admin'
+
+  attribute :disabled, :boolean, default: false
 
   # validations
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -9,7 +9,7 @@ class Category < ApplicationRecord
 
   attribute :disabled, :boolean, default: false
 
-  # validations
+  # validations v1
 
   validates :name, presence: true
 

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,0 +1,10 @@
+class Todo < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :due_date, presence: true
+  validates :priority, presence: true
+  validates :recurring, inclusion: { in: [true, false] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :bid_items, dependent: :destroy
   has_many :bids, dependent: :destroy
   has_many :deposits, dependent: :destroy
+  has_many :todos, dependent: :destroy
 
   # validations
 

--- a/db/migrate/20231122185137_add_disabled_to_categories.rb
+++ b/db/migrate/20231122185137_add_disabled_to_categories.rb
@@ -1,0 +1,6 @@
+class AddDisabledToCategories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :categories, :disabled, :boolean, default: false, null: false
+    add_index :categories, :admin_id
+  end
+end

--- a/db/migrate/20231122185138_add_new_columns_to_users.rb
+++ b/db/migrate/20231122185138_add_new_columns_to_users.rb
@@ -1,0 +1,25 @@
+class AddNewColumnsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :unlock_token, :string
+    add_column :users, :unconfirmed_email, :string
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :remember_created_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :confirmation_token, :string
+    add_column :users, :password, :string
+    add_column :users, :password_confirmation, :string
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+    add_column :users, :locked_at, :datetime
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :email, :string, null: false, default: ''
+    add_column :users, :reset_password_sent_at, :datetime
+    add_column :users, :reset_password_token, :string
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :encrypted_password, :string, null: false, default: ''
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :created_at, :datetime, null: false
+    add_column :users, :updated_at, :datetime, null: false
+  end
+end

--- a/db/migrate/20231122185139_create_todos.rb
+++ b/db/migrate/20231122185139_create_todos.rb
@@ -1,0 +1,17 @@
+class CreateTodos < ActiveRecord::Migration[6.0]
+  def change
+    create_table :todos do |t|
+      t.string :title, null: false
+      t.text :description, null: false
+      t.datetime :due_date, null: false
+      t.integer :priority, null: false
+      t.boolean :recurring, default: false
+      t.json :attachments
+
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [ERD] Changes
| table | guideline | type | columns |
| --- | --- | --- | --- |
| categories | This file already exists. Update the model to include the new "disabled" column. Ensure that the model reflects the correct relationships with the "admins" and "todos" tables, as well as the "product_categories" table. Use Rails associations such as `belongs_to :admin` and `has_many :todos`. | UPDATED | id: integer, disabled: boolean, name: varchar, created_at: date, updated_at: date, admin_id: integer |
| users | This file already exists. Update the model to include the new "disabled" column. Ensure that the model reflects the correct relationships with the "admins" and "todos" tables, as well as the "product_categories" table. Use Rails associations such as `belongs_to :admin` and `has_many :todos`. | UPDATED | id: integer, confirmed_at: date, unlock_token: varchar, unconfirmed_email: varchar, sign_in_count: integer, remember_created_at: date, last_sign_in_at: date, confirmation_token: varchar, password: varchar, password_confirmation: varchar, current_sign_in_ip: varchar, last_sign_in_ip: varchar, locked_at: date, current_sign_in_at: date, email: varchar, reset_password_sent_at: date, reset_password_token: varchar, confirmation_sent_at: date, encrypted_password: varchar, failed_attempts: integer, created_at: date, updated_at: date |
| todos | This file already exists. Update the model to include the new "disabled" column. Ensure that the model reflects the correct relationships with the "admins" and "todos" tables, as well as the "product_categories" table. Use Rails associations such as `belongs_to :admin` and `has_many :todos`. | ADDED | id: integer, created_at: date, updated_at: date, title: varchar, description: text, due_date: date, priority: enum (low, medium, high), recurring: enum (daily, weekly, monthly, none), attachments: file (maximun: undefined), user_id: integer, category_id: integer |
------