### PR TITLE
[Jitera] Create/Update models and migrations

### DIFF
--- a/database/migrations/1716258586094-CreateActiveStorageVariantRecordsTable.ts
+++ b/database/migrations/1716258586094-CreateActiveStorageVariantRecordsTable.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateActiveStorageVariantRecordsTable1716258586094 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: 'active_storage_variant_records',
+            columns: [
+                {
+                    name: 'id',
+                    type: 'int',
+                    isPrimary: true,
+                    isGenerated: true,
+                    generationStrategy: 'increment',
+                },
+                {
+                    name: 'created_at',
+                    type: 'timestamp',
+                    default: 'CURRENT_TIMESTAMP',
+                },
+                {
+                    name: 'updated_at',
+                    type: 'timestamp',
+                    default: 'CURRENT_TIMESTAMP',
+                },
+                {
+                    name: 'variation_digest',
+                    type: 'varchar',
+                },
+                {
+                    name: 'blob_id',
+                    type: 'int',
+                },
+            ],
+        }));
+
+        await queryRunner.createForeignKey('active_storage_variant_records', new TableForeignKey({
+            columnNames: ['blob_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'active_storage_blobs',
+            onDelete: 'CASCADE',
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('active_storage_variant_records');
+    }
+}

--- a/database/migrations/1716258586094-CreateBidItemsTable.ts
+++ b/database/migrations/1716258586094-CreateBidItemsTable.ts
@@ -1,0 +1,79 @@
+import {MigrationInterface, QueryRunner, Table, TableForeignKey} from "typeorm";
+
+export class CreateBidItemsTable1716258586094 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: 'bid_items',
+            columns: [
+                {
+                    name: 'id',
+                    type: 'int',
+                    isPrimary: true,
+                    isGenerated: true,
+                    generationStrategy: 'increment',
+                },
+                {
+                    name: 'created_at',
+                    type: 'timestamp',
+                    default: 'now()',
+                },
+                {
+                    name: 'updated_at',
+                    type: 'timestamp',
+                    default: 'now()',
+                },
+                {
+                    name: 'base_price',
+                    type: 'decimal',
+                    precision: 10,
+                    scale: 2,
+                },
+                {
+                    name: 'name',
+                    type: 'varchar',
+                },
+                {
+                    name: 'expiration_time',
+                    type: 'timestamp',
+                },
+                {
+                    name: 'status',
+                    type: 'varchar',
+                },
+                {
+                    name: 'product_id',
+                    type: 'int',
+                },
+                {
+                    name: 'user_id',
+                    type: 'int',
+                },
+            ],
+        }));
+
+        await queryRunner.createForeignKey('bid_items', new TableForeignKey({
+            columnNames: ['product_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'products',
+            onDelete: 'CASCADE',
+        }));
+
+        await queryRunner.createForeignKey('bid_items', new TableForeignKey({
+            columnNames: ['user_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'users',
+            onDelete: 'CASCADE',
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('bid_items');
+        const productForeignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf('product_id') !== -1);
+        const userForeignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf('user_id') !== -1);
+        await queryRunner.dropForeignKey('bid_items', productForeignKey);
+        await queryRunner.dropForeignKey('bid_items', userForeignKey);
+        await queryRunner.dropTable('bid_items');
+    }
+
+}

--- a/database/migrations/1716258586094-CreateBidsTable.ts
+++ b/database/migrations/1716258586094-CreateBidsTable.ts
@@ -1,0 +1,63 @@
+import {MigrationInterface, QueryRunner, Table, TableForeignKey} from "typeorm";
+
+export class CreateBidsTable1716258586094 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: 'bids',
+            columns: [
+                {
+                    name: 'id',
+                    type: 'int',
+                    isPrimary: true,
+                    isGenerated: true,
+                    generationStrategy: 'increment',
+                },
+                {
+                    name: 'created_at',
+                    type: 'timestamp',
+                    default: 'now()',
+                },
+                {
+                    name: 'updated_at',
+                    type: 'timestamp',
+                    default: 'now()',
+                    onUpdate: 'CURRENT_TIMESTAMP',
+                },
+                {
+                    name: 'status',
+                    type: 'varchar',
+                },
+                {
+                    name: 'item_id',
+                    type: 'int',
+                },
+                {
+                    name: 'price',
+                    type: 'decimal',
+                    precision: 10,
+                    scale: 2,
+                },
+                {
+                    name: 'user_id',
+                    type: 'int',
+                },
+            ]
+        }), true);
+
+        await queryRunner.createForeignKey('bids', new TableForeignKey({
+            columnNames: ['user_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'users',
+            onDelete: 'CASCADE'
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('bids');
+        const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf('user_id') !== -1);
+        await queryRunner.dropForeignKey('bids', foreignKey);
+        await queryRunner.dropTable('bids');
+    }
+
+}

--- a/database/migrations/1716258586094-CreateCategoriesTable.ts
+++ b/database/migrations/1716258586094-CreateCategoriesTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateCategoriesTable1716258586094 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: 'categories',
+            columns: [
+                {
+                    name: 'id',
+                    type: 'int',
+                    isPrimary: true,
+                    isGenerated: true,
+                    generationStrategy: 'increment',
+                },
+                {
+                    name: 'created_at',
+                    type: 'timestamp',
+                    default: 'CURRENT_TIMESTAMP',
+                },
+                {
+                    name: 'updated_at',
+                    type: 'timestamp',
+                    default: 'CURRENT_TIMESTAMP',
+                    onUpdate: 'CURRENT_TIMESTAMP',
+                },
+                {
+                    name: 'disabled',
+                    type: 'boolean',
+                    default: false,
+                },
+                {
+                    name: 'name',
+                    type: 'varchar',
+                },
+                {
+                    name: 'admin_id',
+                    type: 'int',
+                },
+            ],
+        }));
+
+        await queryRunner.createForeignKey('categories', new TableForeignKey({
+            columnNames: ['admin_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'admins',
+            onDelete: 'CASCADE',
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('categories');
+    }
+}

--- a/database/migrations/1716258586094-UpdateAdminsTable.ts
+++ b/database/migrations/1716258586094-UpdateAdminsTable.ts
@@ -1,0 +1,26 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+module.exports = {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('admins', 'current_sign_in_at', {
+      type: DataTypes.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('admins', 'unlock_token', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+    // ... Add other new columns here ...
+    await queryInterface.addColumn('admins', 'password_confirmation', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('admins', 'current_sign_in_at');
+    await queryInterface.removeColumn('admins', 'unlock_token');
+    // ... Remove other new columns here ...
+    await queryInterface.removeColumn('admins', 'password_confirmation');
+  }
+};

--- a/src/models/ActiveStorageVariantRecord.ts
+++ b/src/models/ActiveStorageVariantRecord.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { ActiveStorageBlob } from './ActiveStorageBlob';
+
+@Entity('active_storage_variant_records')
+export class ActiveStorageVariantRecord {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @Column()
+  variation_digest: string;
+
+  @Column()
+  blob_id: number;
+
+  @ManyToOne(() => ActiveStorageBlob)
+  @JoinColumn({ name: 'blob_id' })
+  blob: ActiveStorageBlob;
+}

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -1,0 +1,37 @@
+import { Model, DataTypes } from 'sequelize';
+import { Category, Product, Withdrawal } from './';
+
+class Admin extends Model {
+  static init(sequelize) {
+    super.init({
+      // Assuming other fields are already defined above the patch
+      current_sign_in_at: DataTypes.DATE,
+      unlock_token: DataTypes.STRING,
+      locked_at: DataTypes.DATE,
+      failed_attempts: DataTypes.INTEGER,
+      unconfirmed_email: DataTypes.STRING,
+      encrypted_password: DataTypes.STRING,
+      sign_in_count: DataTypes.INTEGER,
+      last_sign_in_at: DataTypes.DATE,
+      last_sign_in_ip: DataTypes.STRING,
+      confirmation_sent_at: DataTypes.DATE,
+      current_sign_in_ip: DataTypes.STRING,
+      confirmation_token: DataTypes.STRING,
+      confirmed_at: DataTypes.DATE,
+      reset_password_token: DataTypes.STRING,
+      remember_created_at: DataTypes.DATE,
+      password_confirmation: DataTypes.STRING,
+    }, {
+      sequelize,
+      modelName: 'Admin',
+    });
+  }
+
+  static associate(models) {
+    this.hasMany(models.Category, { foreignKey: 'admin_id' });
+    this.hasMany(models.Product, { foreignKey: 'admin_id' });
+    this.hasMany(models.Withdrawal, { foreignKey: 'admin_id' });
+  }
+}
+
+module.exports = Admin;

--- a/src/models/Bid.ts
+++ b/src/models/Bid.ts
@@ -1,0 +1,33 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { User } from './User';
+import { Shipping } from './Shipping';
+
+@Entity()
+export class Bid {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column()
+  status: string;
+
+  @Column()
+  item_id: number;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price: number;
+
+  @Column()
+  user_id: number;
+
+  @ManyToOne(() => User, user => user.bids)
+  user: User;
+
+  @OneToMany(() => Shipping, shipping => shipping.bid)
+  shippings: Shipping[];
+}

--- a/src/models/BidItem.ts
+++ b/src/models/BidItem.ts
@@ -1,0 +1,43 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Product } from './Product';
+import { User } from './User';
+import { ListingBidItem } from './ListingBidItem';
+
+@Entity('bid_items')
+export class BidItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  base_price: number;
+
+  @Column('varchar')
+  name: string;
+
+  @Column('timestamp')
+  expiration_time: Date;
+
+  @Column('varchar')
+  status: string;
+
+  @Column()
+  product_id: number;
+
+  @Column()
+  user_id: number;
+
+  @ManyToOne(() => Product, product => product.bidItems)
+  product: Product;
+
+  @ManyToOne(() => User, user => user.bidItems)
+  user: User;
+
+  @OneToMany(() => ListingBidItem, listingBidItem => listingBidItem.bidItem)
+  listingBidItems: ListingBidItem[];
+}

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Admin } from './Admin';
+import { ProductCategory } from './ProductCategory';
+
+@Entity('categories')
+export class Category {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  @Column({ type: 'boolean' })
+  disabled: boolean;
+
+  @Column({ type: 'varchar' })
+  name: string;
+
+  @Column()
+  admin_id: number;
+
+  @ManyToOne(() => Admin, admin => admin.categories)
+  admin: Admin;
+
+  @OneToMany(() => ProductCategory, productCategory => productCategory.category)
+  productCategories: ProductCategory[];
+}


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [ERD] Changes
| table | guideline | type | columns |
| --- | --- | --- | --- |
| active_storage_variant_records | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, variation_digest: varchar, blob_id: integer |
| admins | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, updated_at: date, current_sign_in_at: date, unlock_token: varchar, locked_at: date, failed_attempts: integer, unconfirmed_email: varchar, email: varchar, encrypted_password: varchar, password: varchar, sign_in_count: integer, name: varchar, reset_password_sent_at: date, last_sign_in_at: date, last_sign_in_ip: varchar, confirmation_sent_at: date, current_sign_in_ip: varchar, confirmation_token: varchar, confirmed_at: date, reset_password_token: varchar, remember_created_at: date, password_confirmation: varchar, created_at: date |
| bid_items | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, base_price: integer, name: varchar, expiration_time: date, status: integer, product_id: integer, user_id: integer |
| bids | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, status: integer, item_id: integer, price: integer, user_id: integer |
| categories | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, disabled: boolean, name: varchar, admin_id: integer |
| shippings | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, updated_at: date, full_name: varchar, shiping_address: varchar, phone_number: varchar, email: varchar, post_code: integer, status: integer, created_at: date, bid_id: integer |
| deposits | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, value: integer, status: integer, payment_method_id: integer, wallet_id: integer, user_id: integer |
| oauth_applications | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, name: varchar, uid: varchar, secret: varchar, redirect_uri: text, scopes: varchar, confidential: boolean |
| listing_bid_items | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, bid_item_id: integer, listing_id: integer |
| listings | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, description: text |
| transactions | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, reference_type: integer, status: integer, transaction_type: integer, reference_id: integer, value: integer, wallet_id: integer |
| oauth_access_grants | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, updated_at: date, resource_owner_id: integer, token: varchar, expires_in: integer, redirect_uri: text, created_at: date, revoked_at: date, scopes: varchar, resource_owner_type: varchar, application_id: integer |
| payment_methods | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, primary: boolean, method: integer, user_id: integer |
| wallets | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, balance: integer, locked: boolean, user_id: integer |
| product_categories | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, category_id: integer, product_id: integer |
| oauth_access_tokens | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, resource_owner_id: integer, token: varchar, refresh_token: varchar, expires_in: integer, revoked_at: date, scopes: varchar, previous_refresh_token: varchar, resource_owner_type: varchar, refresh_expires_in: integer, application_id: integer |
| users | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, confirmed_at: date, unlock_token: varchar, unconfirmed_email: varchar, sign_in_count: integer, remember_created_at: date, last_sign_in_at: date, confirmation_token: varchar, password: varchar, password_confirmation: varchar, current_sign_in_ip: varchar, last_sign_in_ip: varchar, locked_at: date, current_sign_in_at: date, email: varchar, reset_password_sent_at: date, reset_password_token: varchar, confirmation_sent_at: date, encrypted_password: varchar, failed_attempts: integer |
| products | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, price: integer, description: text, name: varchar, stock: integer, admin_id: integer, user_id: integer |
| withdrawals | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, value: integer, status: integer, admin_id: integer, payment_method_id: integer |
| active_storage_blobs | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, key: varchar, filename: varchar, content_type: varchar, metadata: text, service_name: varchar, byte_size: integer, checksum: varchar |
| active_storage_attachments | Create this file to define the ActiveStorageVariantRecord model. Include fields for id, created_at, updated_at, variation_digest, and blob_id with appropriate data types. Set up the relation to ActiveStorageBlob using a ManyToOne decorator, referencing the blob_id. | ADDED | id: integer, created_at: date, updated_at: date, name: varchar, record_type: varchar, record_id: integer, blob_id: integer |
------